### PR TITLE
Improve speed of package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,13 @@ RUN mkdir "${HOME}/app"
 
 WORKDIR "${HOME}/app"
 
+RUN julia -e 'using Pkg; Pkg.update(); \
+    Pkg.add(PackageSpec.(["CSV", "Images", "Plots", "Pluto", "Statistics"]))'
+
 COPY . "${HOME}/app"
 
 RUN python3 -m pip install -U pip \
  && python3 -m pip install -e .
-
-RUN julia -e 'import Pkg; Pkg.update()' && \
-    julia -e 'import Pkg; Pkg.add("CSV")' && \
-    julia -e 'import Pkg; Pkg.add("Images")' && \
-    julia -e 'import Pkg; Pkg.add("Plots")' && \
-    julia -e 'import Pkg; Pkg.add("Pluto")' && \
-    julia -e 'import Pkg; Pkg.add("Statistics")'
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install -e .
 ## Credits
 
 - [`jupyter-server-proxy`](https://github.com/jupyterhub/jupyter-server-proxy)
-- [`Pluto.jl](https://github.com/fonsp/Pluto.jl)
+- [`Pluto.jl`](https://github.com/fonsp/Pluto.jl)
 
 ## License
 


### PR DESCRIPTION
The Julia package installation step used to precompile everything multiple times. After this PR, all packages are installed at once which avoids precompiling multiple times. This will speed up the build by a minute or so.

Also, I've moved the `RUN` statement before `COPY . "${HOME}/app"`. When a file inside the local directory (`.`) changes, Docker will rerun all steps after that from scratch. Since the Julia package installation step doesn't depend on the files inside the directory, the statement can be moved up. This will speed up developer build time when changing files.